### PR TITLE
add header file to survive compilation

### DIFF
--- a/src/utils/BaseUtil.h
+++ b/src/utils/BaseUtil.h
@@ -133,6 +133,7 @@
 #include <vector>
 #include <limits>
 #include <span>
+#include <atomic>
 //#include <iostream>
 //#include <locale>
 


### PR DESCRIPTION
The building failed due to the error saying "No type named 'atomic' in namespace 'std'". So I included the <atomic> header here.
